### PR TITLE
Some tweaks

### DIFF
--- a/frontend/src/main/scala/example/akkawschat/Frontend.scala
+++ b/frontend/src/main/scala/example/akkawschat/Frontend.scala
@@ -5,6 +5,11 @@ import org.scalajs.dom.raw._
 import scala.scalajs.js
 import org.scalajs.dom
 
+import upickle._
+
+// TODO - Definition should move to a separate shared sub-project between client and server. 
+case class ChatMessage(sender: String, message: String)
+
 object Frontend extends js.JSApp {
   val joinButton = dom.document.getElementById("join").asInstanceOf[HTMLButtonElement]
   val sendButton = dom.document.getElementById("send").asInstanceOf[HTMLButtonElement]
@@ -56,7 +61,8 @@ object Frontend extends js.JSApp {
       sendButton.disabled = true
     }
     chat.onmessage = { (event: MessageEvent) ⇒
-      playground.insertBefore(p(event.data.toString), playground.firstChild)
+      val wsMsg = read[ChatMessage](event.data.toString)
+      playground.insertBefore(p(s"${wsMsg.sender} said: ${wsMsg.message}"), playground.firstChild)
     }
     chat.onclose = { (event: Event) ⇒
       playground.insertBefore(p("Connection to chat lost. You can try to rejoin manually."), playground.firstChild)

--- a/project/ChatBuild.scala
+++ b/project/ChatBuild.scala
@@ -23,6 +23,7 @@ object ChatBuild extends Build {
         testFrameworks += new TestFramework("utest.runner.Framework"),
         libraryDependencies ++= Seq(
           "org.scala-js" %%% "scalajs-dom" % "0.8.0",
+          "com.lihaoyi" %%% "upickle" % "0.2.8",
           "com.lihaoyi" %%% "utest" % "0.3.0" % "test"
         )
       )
@@ -35,7 +36,8 @@ object ChatBuild extends Build {
       .settings(
         libraryDependencies ++= Seq(
           "com.typesafe.akka" %% "akka-http-experimental" % "1.0-RC4",
-          "org.specs2" %% "specs2" % "2.3.12" % "test"
+          "org.specs2" %% "specs2" % "2.3.12" % "test",
+          "com.lihaoyi" %% "upickle" % "0.2.8"
         ),
         (resourceGenerators in Compile) <+=
           (fastOptJS in Compile in frontend, packageScalaJSLauncher in Compile in frontend)


### PR DESCRIPTION
Updated build file to move to akka-streams RC4.
Added sbt-eclipse project definition to generate eclipse project files.

This last change you may not agree with :-)

I also changed materialization to explicitly pass the materialized chatOutSource on to the Chat actor rather than passing the materialized value through the flow which I found to be a very confusing approach.  I.e. passing the result of constructing the flow back into the flow.  I prefer an approach of having a clean separation from the construction of a flow vs the data that goes through the flow once it has been constructed.

Cheers,
Rob
